### PR TITLE
Add library info to supergood-bound headers

### DIFF
--- a/lib/supergood/api.rb
+++ b/lib/supergood/api.rb
@@ -8,7 +8,9 @@ module Supergood
       @base_url = base_url
       @header_options = {
         'Content-Type' => 'application/json',
-        'Authorization' => 'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub(/\n/, '')
+        'Authorization' => 'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub(/\n/, ''),
+        'supergood-api' => 'supergood-rb',
+        'supergood-api-version' => VERSION
       }
       @local_only = client_id == LOCAL_CLIENT_ID && client_secret == LOCAL_CLIENT_SECRET
     end

--- a/lib/supergood/version.rb
+++ b/lib/supergood/version.rb
@@ -1,3 +1,3 @@
 module Supergood
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
This PR includes the library and library version in the header of requests being made to supergood. These are consumed on supergood's side and used for debugging.