### PR TITLE
[Feat] sensitive key redaction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.tabSize": 2,
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    supergood (0.1.3)
+    supergood (0.1.5)
       rudash (~> 4.0, >= 4.0.2)
 
 GEM

--- a/lib/supergood/api.rb
+++ b/lib/supergood/api.rb
@@ -8,7 +8,7 @@ module Supergood
       @base_url = base_url
       @header_options = {
         'Content-Type' => 'application/json',
-        'Authorization' => 'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub(/\n/, ''),
+        'Authorization' => "Basic #{Base64.encode64("#{client_id}:#{client_secret}").gsub(/\n/, '')}",
         'supergood-api' => 'supergood-rb',
         'supergood-api-version' => VERSION
       }
@@ -31,11 +31,12 @@ module Supergood
       if @local_only
         @log.debug(payload)
       else
-        uri = URI(@base_url + '/events')
+        uri = URI("#{@base_url}/events")
         response = Net::HTTP.post(uri, payload.to_json, @header_options)
-        if response.code == '200'
-          return JSON.parse(response.body)
-        elsif response.code == '401'
+
+        return JSON.parse(response.body) if response.code == '200'
+
+        if response.code == '401'
           raise SupergoodException.new ERRORS[:UNAUTHORIZED]
         elsif response.code != '200' && response.code != '201'
           raise SupergoodException.new ERRORS[:POSTING_EVENTS]
@@ -47,24 +48,20 @@ module Supergood
       if @local_only
         @log.debug(payload)
       else
-        uri = URI(@base_url + '/errors')
+        uri = URI("#{@base_url}/errors")
         response = Net::HTTP.post(uri, payload.to_json, @header_options)
-        if response.code == '200'
-          return JSON.parse(response.body, symbolize_names: true)
-        else
-          @log.warn(ERRORS[:POSTING_ERRORS])
-        end
+        return JSON.parse(response.body, symbolize_names: true) if response.code == '200'
+
+        @log.warn(ERRORS[:POSTING_ERRORS])
       end
     end
 
     def get_remote_config
       uri = URI(@base_url + '/config')
       response = Net::HTTP.get_response(uri, @header_options)
-      if response.code == '200'
-        return JSON.parse(response.body)
-      else
-        raise SupergoodException.new ERRORS[:CONFIG_FETCH_ERROR]
-      end
+      return JSON.parse(response.body) if response.code == '200'
+
+      raise SupergoodException.new ERRORS[:CONFIG_FETCH_ERROR]
     end
   end
 end

--- a/lib/supergood/api.rb
+++ b/lib/supergood/api.rb
@@ -56,5 +56,15 @@ module Supergood
         end
       end
     end
+
+    def get_remote_config
+      uri = URI(@base_url + '/config')
+      response = Net::HTTP.get_response(uri, @header_options)
+      if response.code == '200'
+        return JSON.parse(response.body, symbolize_names: true)
+      else
+        raise SupergoodException.new ERRORS[:CONFIG_FETCH_ERROR]
+      end
+    end
   end
 end

--- a/lib/supergood/api.rb
+++ b/lib/supergood/api.rb
@@ -34,7 +34,7 @@ module Supergood
         uri = URI(@base_url + '/events')
         response = Net::HTTP.post(uri, payload.to_json, @header_options)
         if response.code == '200'
-          return JSON.parse(response.body, symbolize_names: true)
+          return JSON.parse(response.body)
         elsif response.code == '401'
           raise SupergoodException.new ERRORS[:UNAUTHORIZED]
         elsif response.code != '200' && response.code != '201'
@@ -61,7 +61,7 @@ module Supergood
       uri = URI(@base_url + '/config')
       response = Net::HTTP.get_response(uri, @header_options)
       if response.code == '200'
-        return JSON.parse(response.body, symbolize_names: true)
+        return JSON.parse(response.body)
       else
         raise SupergoodException.new ERRORS[:CONFIG_FETCH_ERROR]
       end

--- a/lib/supergood/client.rb
+++ b/lib/supergood/client.rb
@@ -62,7 +62,6 @@ module Supergood
     def fetch_and_process_remote_config
       begin
         remote_config = @api.get_remote_config
-        puts remote_config
         @config = @config.merge({ :remote_config => Supergood::Utils.process_remote_config(remote_config) })
       rescue => e
         log.error({}, e, ERRORS[:CONFIG_FETCH_ERROR])
@@ -78,8 +77,8 @@ module Supergood
         return
       end
 
-      data = Supergood::Utils.prepare_data(@response_cache.values, @config[:remote_config])
-      data += Supergood::Utils.prepare_data(@request_cache.values, @config[:remote_config]) if force
+      data = Supergood::Utils.prepare_data(@response_cache.values, @config[:remote_config], @config[:forceRedactAll])
+      data += Supergood::Utils.prepare_data(@request_cache.values, @config[:remote_config], @config[:forceRedactAll]) if force
 
       begin
         api.post_events(data)

--- a/lib/supergood/client.rb
+++ b/lib/supergood/client.rb
@@ -135,8 +135,8 @@ module Supergood
       request_id = SecureRandom.uuid
       requested_at = Time.now
 
-      endpoint_config = Supergood::Utils.get_endpoint_config(request, remote_config)
-      ignore_endpoint = endpoint_config ? endpoint_config[:ignored] : false
+      endpoint_config = Supergood::Utils.get_endpoint_config(request.transform_keys(&:to_s), remote_config)
+      ignore_endpoint = endpoint_config ? endpoint_config['ignored'] : false
 
       if !ignore_endpoint && !ignored?(request[:domain])
         cache_request(request_id, requested_at, request)
@@ -157,20 +157,20 @@ module Supergood
 
       begin
         request_payload = {
-          id: request_id,
-          headers: request[:headers],
-          method: request[:method],
-          url: request[:url],
-          path: request[:path],
-          search: request[:search] || '',
-          body: Supergood::Utils.safe_parse_json(request[:body]),
-          requestedAt: requested_at
+          'id' => request_id,
+          'headers' => Supergood::Utils.safe_parse_json(request[:headers]),
+          'method' => request[:method],
+          'url' => request[:url],
+          'path' => request[:path],
+          'search' => request[:search] || '',
+          'body' => Supergood::Utils.safe_parse_json(request[:body]),
+          'requestedAt' => requested_at
         }
         @request_cache[request_id] = {
-          request: request_payload
+          'request' => request_payload
         }
       rescue => e
-        log.error({ request: request }, e, ERRORS[:CACHING_REQUEST])
+        log.error({ 'request' => request }, e, ERRORS[:CACHING_REQUEST])
       end
     end
 
@@ -184,14 +184,14 @@ module Supergood
         duration = (responded_at - requested_at) * 1000
         request_payload = @request_cache[request_id]
         response_payload = {
-          headers: response[:headers],
-          status: response[:status],
-          statusText: response[:statusText],
-          body: Supergood::Utils.safe_parse_json(response[:body]),
-          respondedAt: responded_at,
-          duration: duration.round,
+          'headers' => Supergood::Utils.safe_parse_json(response[:headers]),
+          'status' => response[:status],
+          'statusText' => response[:statusText],
+          'body' => Supergood::Utils.safe_parse_json(response[:body]),
+          'respondedAt' => responded_at,
+          'duration' => duration.round
         }
-        @response_cache[request_id] = request_payload.merge({ response: response_payload })
+        @response_cache[request_id] = request_payload.merge({ 'response' => response_payload })
         @request_cache.delete(request_id)
       rescue => e
         log.error(

--- a/lib/supergood/constants.rb
+++ b/lib/supergood/constants.rb
@@ -17,12 +17,12 @@ ERRORS = {
 LOCAL_CLIENT_ID = 'local-client-id';
 LOCAL_CLIENT_SECRET = 'local-client-secret';
 
-DEFAULT_SUPERGOOD_BYTE_LIMIT = 500000
+DEFAULT_SUPERGOOD_BYTE_LIMIT = 500_000
 
 DEFAULT_CONFIG = {
   keysToHash: [],
   flushInterval: 1000,
-  remoteConfigFetchInterval: 10000,
+  remoteConfigFetchInterval: 10_000,
   ignoredDomains: [],
   allowedDomains: [],
   forceRedactAll: true

--- a/lib/supergood/constants.rb
+++ b/lib/supergood/constants.rb
@@ -5,7 +5,8 @@ ERRORS = {
   POSTING_EVENTS: 'Error Posting Events',
   POSTING_ERRORS: 'Error Posting Errors',
   WRITING_TO_DISK: 'Error writing to disk',
-  TEST_ERROR: 'Test Error for Testing Purpos es',
+  TEST_ERROR: 'Test Error for Testing Purposes',
+  CONFIG_FETCH_ERROR: 'Error Fetching Remote Config',
   UNAUTHORIZED: 'Unauthorized: Invalid Client ID or Secret. Exiting.',
   NO_CLIENT_ID:
     'No Client ID Provided, set SUPERGOOD_CLIENT_ID or pass it as an argument',
@@ -21,8 +22,10 @@ DEFAULT_SUPERGOOD_BYTE_LIMIT = 500000
 DEFAULT_CONFIG = {
   keysToHash: [],
   flushInterval: 1000,
+  remoteConfigFetchInterval: 10000,
   ignoredDomains: [],
   allowedDomains: [],
+  forceRedactAll: true
 }
 
 # GZIP_START_BYTES = b'\x1f\x8b'

--- a/lib/supergood/constants.rb
+++ b/lib/supergood/constants.rb
@@ -20,7 +20,6 @@ LOCAL_CLIENT_SECRET = 'local-client-secret';
 DEFAULT_SUPERGOOD_BYTE_LIMIT = 500_000
 
 DEFAULT_CONFIG = {
-  keysToHash: [],
   flushInterval: 1000,
   remoteConfigFetchInterval: 10_000,
   ignoredDomains: [],

--- a/lib/supergood/logger.rb
+++ b/lib/supergood/logger.rb
@@ -13,7 +13,9 @@ module Supergood
     end
 
     def error(data, error, msg)
-      super(error)
+      if(ENV['SUPERGOOD_LOG_LEVEL'] == 'debug')
+        super(error)
+      end
       @api.post_errors(
         {
           error: error.backtrace.join('\n'),

--- a/lib/supergood/utils.rb
+++ b/lib/supergood/utils.rb
@@ -241,13 +241,13 @@ module Supergood
       sensitive_keys = expand_sensitive_key_set_for_arrays(
         event, sensitive_keys.map { |key| marshal_key_path(key) }
       )
+
+      puts "Sensitive keys: #{sensitive_keys}"
       sensitive_keys.each do |key_path|
         value = R_.get(event, key_path)
-        if !value.nil?
-          event = set_value_to_nil(event, key_path)
-          # Add sensitive key for array expansion
-          sensitive_key_metadata << { keyPath: unmarshal_key_path(key_path) }.merge(redact_value(value))
-        end
+        event = set_value_to_nil(event, key_path)
+        # Add sensitive key for array expansion
+        sensitive_key_metadata << { keyPath: unmarshal_key_path(key_path) }.merge(redact_value(value))
       end
 
       { event: event, sensitive_key_metadata: sensitive_key_metadata }

--- a/lib/supergood/utils.rb
+++ b/lib/supergood/utils.rb
@@ -242,7 +242,6 @@ module Supergood
         event, sensitive_keys.map { |key| marshal_key_path(key) }
       )
 
-      puts "Sensitive keys: #{sensitive_keys}"
       sensitive_keys.each do |key_path|
         value = R_.get(event, key_path)
         event = set_value_to_nil(event, key_path)

--- a/lib/supergood/utils.rb
+++ b/lib/supergood/utils.rb
@@ -1,62 +1,27 @@
 require 'rudash'
 require 'digest'
+require 'uri'
+require 'json'
 
 module Supergood
   module Utils
-    def self.hash_value(input)
-      hash = Digest::SHA1.new
-      if input == nil
-        return ''
-      elsif input.class == Array
-        return [Base64.strict_encode64(hash.update(input.to_json).to_s)]
-      elsif input.class == Hash
-        return {'hashed': Base64.strict_encode64(hash.update(input.to_json).to_s)}
-      elsif input.class == String
-        return Base64.strict_encode64(hash.update(input).to_s)
-      end
-    end
 
-    # Hash values from specified keys, or hash if the bodies exceed a byte limit
-    def self.hash_values_from_keys(obj, keys_to_hash, byte_limit=DEFAULT_SUPERGOOD_BYTE_LIMIT)
-      _obj = obj
-
-      if !keys_to_hash.include?('response.body')
-        payload = R_.get(_obj, 'response.body')
-        payload_size = payload.to_s.length()
-        if(payload_size >= byte_limit)
-          R_.set(_obj, 'response.body', Supergood::Utils.hash_value(payload))
-        end
-      end
-
-      if !keys_to_hash.include?('request.body')
-        payload = R_.get(_obj, 'request.body')
-        payload_size = payload.to_s.length()
-        if(payload_size >= byte_limit)
-          R_.set(_obj, 'request.body', Supergood::Utils.hash_value(payload))
-        end
-      end
-
-      keys_to_hash.each { |key|
-        value = R_.get(_obj, key)
-        if !!value
-          R_.set(_obj, key, Supergood::Utils.hash_value(value))
-        end
-      }
-
-      return _obj
+    def self.get_host_without_www(url)
+      uri = URI.parse(url)
+      uri = URI.parse("http://#{url}") if uri.scheme.nil?
+      host = uri.host.downcase
+      host.start_with?('www.') ? host[4..-1] : host
     end
 
     def self.safe_parse_json(input)
-      if !input || input == ''
-        return ''
-      end
-
+      return '' if !input || input == ''
       begin
-        return JSON.parse(input)
+        JSON.parse(input)
       rescue => e
         input
       end
     end
+
     def self.get_header(request_or_response)
       header = {}
       request_or_response.each_header do |k,v|
@@ -70,7 +35,209 @@ module Supergood
     end
 
     def self.make_config(config)
-      return DEFAULT_CONFIG.merge(config)
+      DEFAULT_CONFIG.merge(config)
+    end
+
+    def self.process_remote_config(remote_config_payload)
+      remote_config_payload ||= []
+      remote_config_payload.reduce({}) do |remote_config, domain_config|
+        domain = domain_config[:domain]
+        endpoints = domain_config[:endpoints]
+        endpoint_config = endpoints.reduce({}) do |config, endpoint|
+          matching_regex = endpoint[:matchingRegex]
+          regex = matching_regex[:regex]
+          location = matching_regex[:location]
+
+          endpoint_configuration = endpoint[:endpointConfiguration]
+          action = endpoint_configuration[:action]
+          sensitive_keys = endpoint_configuration[:sensitiveKeys] || []
+          sensitive_keys = sensitive_keys.map { |key| key[:keyPath] }
+
+          config[regex] = {
+            location: location,
+            regex: regex,
+            ignored: action == 'Ignore',
+            sensitive_keys: sensitive_keys
+          }
+
+          config
+        end
+
+        remote_config[domain] = endpoint_config
+        remote_config
+      end
+    end
+
+    def self.get_str_representation_from_path(request, location)
+      url = URI(request[:url])
+
+      case location
+      when 'domain'
+        get_host_without_www(url)
+      when 'url'
+        url.to_s
+      when 'path'
+        url.path
+      when 'requestHeaders'
+        request['headers'].to_s
+      when 'requestBody'
+        request['body'].to_s
+      else
+        request[location.to_sym].to_s if request.key?(location.to_sym)
+      end
+    end
+
+    def self.get_endpoint_config(request, remote_config)
+      domain = remote_config.keys.find { |d| get_host_without_www(request[:url]).include?(d) }
+      return nil unless domain
+
+      endpoint_configs = remote_config[domain]
+      endpoint_configs.each_value do |endpoint_config|
+        regex = endpoint_config[:regex]
+        location = endpoint_config[:location]
+        regex_obj = Regexp.new(regex)
+        str_representation = get_str_representation_from_path(request, location)
+        next unless str_representation
+        return endpoint_config if regex_obj.match?(str_representation)
+      end
+      nil
+    end
+
+    def self.expand(parts, obj, key_path)
+      # puts "parts: #{parts}, key_path: #{key_path}"
+      path = key_path
+      return [path] if parts.empty?
+
+      part = parts.first
+      is_property = !part.start_with?('[')
+      separator = !path.empty? && is_property ? '.' : ''
+
+      # Check for array notations
+      if part.match?(/\[\*?\]/)
+        return [] unless obj.is_a?(Array)
+
+        # Expand for each element in the array
+        obj.flat_map.with_index do |_, index|
+          expand(parts[1..-1], obj[index], "#{path}#{separator}[#{index}]")
+        end
+      elsif part.start_with?('[') && part.end_with?(']')
+        # Specific index in the array
+        index = part[1...-1].to_i
+        if index.is_a?(Numeric) && index < obj.length
+          expand(parts[1..-1], obj[index], "#{path}#{separator}#{part}")
+        else
+          []
+        end
+      else
+        if obj && obj.is_a?(Hash) && (obj.key?(part.to_sym) || obj.key?(part))
+          expand(parts[1..-1], obj.fetch(part.to_sym, obj[part]), "#{path}#{separator}#{part}")
+        else
+          []
+        end
+      end
+    end
+
+    def self.expand_key(key, obj)
+      parts = key.scan(/[^.\[\]]+|\[\d*\]|\[\*\]/) || []
+      expand(parts, obj, '')
+    end
+
+    def self.expand_sensitive_key_set_for_arrays(obj, sensitive_keys)
+      sensitive_keys.flat_map { |key| expand_key(key, obj) }
+    end
+
+    def self.marshal_key_path(keypath)
+      keypath.gsub(/^requestHeaders/, 'request.headers')
+             .gsub(/^requestBody/, 'request.body')
+             .gsub(/^responseHeaders/, 'response.headers')
+             .gsub(/^responseBody/, 'response.body')
+    end
+
+    def self.unmarshal_key_path(keypath)
+      keypath.gsub(/^request\.headers/, 'requestHeaders')
+             .gsub(/^request\.body/, 'requestBody')
+             .gsub(/^response\.headers/, 'responseHeaders')
+             .gsub(/^response\.body/, 'responseBody')
+    end
+
+    def self.set_value_to_nil(hash, key_path)
+      keys = key_path.split('.')
+      current_key = keys.first
+      index = current_key.match(/\[(\d+)\]/)
+      if index
+        index = index[1].to_i
+      end
+      # Convert current_key to symbol if necessary
+      if index
+        current_key = current_key.gsub(/\[\d+\]/, '')
+      elsif hash.keys.include?(current_key.to_sym)
+        current_key = current_key.to_sym
+      end
+
+      return hash unless hash.keys.include?(current_key)
+
+      if keys.length == 1
+        hash[current_key] = nil
+      elsif hash[current_key].is_a?(Hash)
+        set_value_to_nil(hash[current_key], keys[1..].join('.'))
+      elsif hash[current_key].is_a?(Array)
+        set_value_to_nil(hash[current_key][index], keys[1..].join('.'))
+      end
+
+      hash
+    end
+
+    def self.redact_values_from_keys(event, remote_config)
+      sensitive_key_metadata = []
+      endpoint_config = get_endpoint_config(event[:request], remote_config)
+      unless endpoint_config && endpoint_config[:sensitive_keys].any?
+        return { event: event, sensitive_key_metadata: sensitive_key_metadata }
+      end
+      sensitive_keys = expand_sensitive_key_set_for_arrays(
+        event, endpoint_config[:sensitive_keys].map { |key| marshal_key_path(key) }
+      )
+      sensitive_keys.each do |key_path|
+        value = R_.get(event, key_path)
+        if !(value.nil? || value.empty?)
+          event = set_value_to_nil(event, key_path)
+          # Add sensitive key for array expansion
+          sensitive_key_metadata << { keyPath: unmarshal_key_path(key_path) }.merge(redact_value(value))
+        end
+      end
+
+      { event: event, sensitive_key_metadata: sensitive_key_metadata }
+    end
+
+    def self.redact_value(input)
+      data_length = 0
+      data_type = 'null'
+      case input
+      when Array
+        data_length = input.size
+        data_type = 'array'
+      when Hash
+        data_length = input.to_json.bytesize
+        data_type = 'object'
+      when String
+        data_length = input.size
+        data_type = 'string'
+      when Numeric
+        data_length = input.to_s.size
+        data_type = input.integer? ? 'integer' : 'float'
+      when TrueClass, FalseClass # This is a better way to check for booleans
+        data_length = 1
+        data_type = 'boolean'
+      end
+      { length: data_length, type: data_type }
+    end
+
+    def self.prepare_data(events, remote_config)
+      events.map do |event|
+        redacted_event_with_metadata = redact_values_from_keys(event, remote_config)
+        redacted_event_with_metadata[:event].merge(
+          metadata: { sensitiveKeys: redacted_event_with_metadata[:sensitive_key_metadata] }
+        )
+      end
     end
   end
 end

--- a/lib/supergood/utils.rb
+++ b/lib/supergood/utils.rb
@@ -10,11 +10,12 @@ module Supergood
       uri = URI.parse(url)
       uri = URI.parse("http://#{url}") if uri.scheme.nil?
       host = uri.host.downcase
-      host.start_with?('www.') ? host[4..-1] : host
+      host.start_with?('www.') ? host[4..] : host
     end
 
     def self.safe_parse_json(input)
       return '' if !input || input == ''
+
       begin
         JSON.parse(input)
       rescue => e
@@ -31,7 +32,7 @@ module Supergood
     end
 
     def self.request_url(http, request)
-      URI::DEFAULT_PARSER.unescape("http#{"s" if http.use_ssl?}://#{http.address}#{request.path}")
+      URI::DEFAULT_PARSER.unescape("http#{'s' if http.use_ssl?}://#{http.address}#{request.path}")
     end
 
     def self.make_config(config)
@@ -117,19 +118,19 @@ module Supergood
 
         # Expand for each element in the array
         obj.flat_map.with_index do |_, index|
-          expand(parts[1..-1], obj[index], "#{path}#{separator}[#{index}]")
+          expand(parts[1..], obj[index], "#{path}#{separator}[#{index}]")
         end
       elsif part.start_with?('[') && part.end_with?(']')
         # Specific index in the array
         index = part[1...-1].to_i
         if index.is_a?(Numeric) && index < obj.length
-          expand(parts[1..-1], obj[index], "#{path}#{separator}#{part}")
+          expand(parts[1..], obj[index], "#{path}#{separator}#{part}")
         else
           []
         end
       else
         if obj && obj.is_a?(Hash) && obj.key?(part)
-          expand(parts[1..-1], obj[part], "#{path}#{separator}#{part}")
+          expand(parts[1..], obj[part], "#{path}#{separator}#{part}")
         else
           []
         end
@@ -164,16 +165,10 @@ module Supergood
       current_key = keys.first
       index = current_key.match(/\[(\d+)\]/)
 
-      if index
-        index = index[1].to_i
-      end
+      index = index[1].to_i if index
 
       # Convert current_key to symbol if necessary
-      if index
-        current_key = current_key.gsub(/\[\d+\]/, '')
-      elsif hash.keys.include?(current_key)
-        current_key = current_key
-      end
+      current_key = current_key.gsub(/\[\d+\]/, '') if index
 
       return hash unless hash.keys.include?(current_key)
 

--- a/lib/supergood/vendors/http.rb
+++ b/lib/supergood/vendors/http.rb
@@ -14,7 +14,7 @@ module Supergood
                 url: original_request_payload.uri.to_s,
                 path: original_request_payload.uri.path,
                 search: original_request_payload.uri.query,
-                domain: original_request_payload.uri.host
+                domain: Supergood::Utils.get_host_without_www(original_request_payload.uri.host)
               }
               Supergood.intercept(request) do
                 original_response = original_perform(original_request_payload, original_options)

--- a/lib/supergood/vendors/net-http.rb
+++ b/lib/supergood/vendors/net-http.rb
@@ -10,7 +10,7 @@ module Supergood
           block = lambda do |x|
             alias original_request_method request
             def request(original_request_payload, body = nil, &block)
-              http = self;
+              http = self
               url = Supergood::Utils.request_url(http, original_request_payload)
               uri = URI.parse(url)
               request = {
@@ -20,7 +20,7 @@ module Supergood
                 url: url,
                 path: original_request_payload.path,
                 search: uri.query,
-                domain: uri.host,
+                domain: Supergood::Utils.get_host_without_www(uri.host)
               }
               Supergood.intercept(request) do
                 original_response = original_request_method(original_request_payload, body, &block)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -62,23 +62,23 @@ describe Supergood do
     it 'captures all outgoing 200 http requests' do
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_remote_config
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
-        req.body[0][:response] != nil
-      }).
-      to have_been_made.once
+        !req.body[0][:request].nil? &&
+        !req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
 
     it 'captures non-success status and errors' do
       http_error_codes = [400, 401, 403, 404, 500, 501, 502, 503, 504]
       stub_remote_config
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
 
       for http_error_code in http_error_codes do
         stub_request(:get, OUTBOUND_URL + '/' + http_error_code.to_s).
@@ -100,18 +100,18 @@ describe Supergood do
     it 'post requests successfully' do
       stub_request(:post, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_remote_config
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       conn = Faraday.new(url: OUTBOUND_URL)
-      response = conn.post('/')
-      Supergood.close()
+      conn.post('/')
+      Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
+        !req.body[0][:request].nil? &&
         req.body[0][:request][:method] == 'POST' &&
-        req.body[0][:response] != nil
-      }).
-      to have_been_made.once
+        !req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
   end
 
@@ -119,11 +119,11 @@ describe Supergood do
     it 'does not post requests externally when keys are local' do
       stub_remote_config
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
-      config = { client_id: 'local-client-id', client_secret: 'local-client-secret' }
+      config = { client_id: 'local-client-id', client_secret: 'local-client-secret', forceRedactAll: false }
 
       Supergood.init(config)
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events')).
       to have_not_been_made
@@ -135,51 +135,51 @@ describe Supergood do
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_remote_config
 
-      Supergood.init
-      Supergood.init
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
+      Supergood.init({ forceRedactAll: false })
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
       Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
-        req.body[0][:response] != nil
-      }).
-      to have_been_made.once
+        !req.body[0][:request].nil? &&
+        !req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
 
     it 'does not fail when close is called multiple times' do
       stub_remote_config
-      stub_request(:get, OUTBOUND_URL).
-      to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
+      stub_request(:get, OUTBOUND_URL)
+        .to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
 
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
-      Supergood.close()
-      Supergood.close()
+      Supergood.close
+      Supergood.close
+      Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
-        req.body[0][:response] != nil
-      }).
-      to have_been_made.once
+        !req.body[0][:request].nil? &&
+        !req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
   end
 
   describe 'teardown' do
     it 'closes the client and does not intercept subsequent requests' do
       stub_remote_config
-      stub_request(:get, OUTBOUND_URL).
-      to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
+      stub_request(:get, OUTBOUND_URL)
+        .to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
 
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
 
       Faraday.get(OUTBOUND_URL)
       Faraday.get(OUTBOUND_URL)
@@ -188,10 +188,10 @@ describe Supergood do
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
-        req.body[0][:response] != nil
-      }).
-      to have_been_made.once
+        !req.body[0][:request].nil? &&
+        !req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
   end
 
@@ -199,7 +199,7 @@ describe Supergood do
     it 'reports timeout properly' do
       stub_remote_config
       stub_request(:get, OUTBOUND_URL).to_timeout
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
 
       begin
         Faraday.get(OUTBOUND_URL)
@@ -211,10 +211,10 @@ describe Supergood do
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:request] != nil &&
-        req.body[0][:response] == nil
-      }).
-      to have_been_made.once
+        !req.body[0][:request].nil? &&
+        req.body[0][:response].nil?
+      })
+        .to have_been_made.once
     end
 
     it 'reports errors properly' do
@@ -224,9 +224,9 @@ describe Supergood do
       stub_request(:post,  ENV['SUPERGOOD_BASE_URL'] + '/errors').to_return(status: 200, body: { message: 'Success' }.to_json, headers: {})
       stub_request(:post,  ENV['SUPERGOOD_BASE_URL'] + '/events').to_raise(SupergoodException.new ERRORS[:POSTING_EVENTS])
 
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/errors').
       with { | req |
         req.body = JSON.parse(req.body, symbolize_names: true)
@@ -240,9 +240,9 @@ describe Supergood do
     it 'ignores caching specified domains' do
       stub_remote_config
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
-      Supergood.init(config={ ignoredDomains: ['example.com'] })
+      Supergood.init({ ignoredDomains: ['example.com'], forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events')).
       to have_not_been_made
     end
@@ -253,10 +253,10 @@ describe Supergood do
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_request(:get, SECOND_OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
 
-      Supergood.init(config={ allowedDomains: ['example-2.com'] })
+      Supergood.init({ allowedDomains: ['example-2.com'], forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
       Faraday.get(SECOND_OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
@@ -271,10 +271,10 @@ describe Supergood do
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_request(:get, SECOND_OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
 
-      Supergood.init(config={ allowedDomains: ['example-2.com'], ignoredDomains: ['example-2.com'] })
+      Supergood.init({ forceRedactAll: false, allowedDomains: ['example-2.com'], ignoredDomains: ['example-2.com'] })
       Faraday.get(OUTBOUND_URL)
       Faraday.get(SECOND_OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
@@ -290,10 +290,10 @@ describe Supergood do
       stub_remote_config
       PAYLOAD_SIZE_300kb = 300000
       payload = { payload: 'X' * PAYLOAD_SIZE_300kb }.to_json
-      stub_request(:get, OUTBOUND_URL).
-      to_return(status: 200, body: payload, headers: {})
+      stub_request(:get, OUTBOUND_URL)
+        .to_return(status: 200, body: payload, headers: {})
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
       Supergood.close
 
@@ -301,13 +301,50 @@ describe Supergood do
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
         req.body[0][:response][:body].to_json == payload &&
-        req.body[0][:request] != nil
+        !req.body[0][:request].nil?
       }).to have_been_made.once
     end
   end
 
   describe 'redact by default' do
     it 'redacts all data by default when flag set' do
+      stub_remote_config
+      stub_request(:get, OUTBOUND_URL).to_return(
+        status: 200,
+        body: {
+          message: 'success',
+          txns: [
+            { user: 'Alex', id: 1 },
+            { user: 'Steve', id: 2 }
+          ],
+          payment_method: {
+            type: 'card',
+            card: {
+              numbers: [1,2,3,4]
+            }
+          }
+        }.to_json,
+        headers: { 'Content-Type' => 'application/json', 'Content-Encoding' => 'gzip' }
+      )
+      Supergood.init
+      Faraday.get(OUTBOUND_URL)
+      Supergood.close
+
+      expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events')
+        .with { |req|
+        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body[0][:response][:body][:txns][0][:user].nil? &&
+        req.body[0][:response][:body][:txns][0][:id].nil? &&
+        req.body[0][:response][:body][:txns][1][:user].nil? &&
+        req.body[0][:response][:body][:txns][1][:id].nil? &&
+        req.body[0][:response][:body][:payment_method][:type].nil? &&
+        req.body[0][:response][:body][:payment_method][:card][:numbers][0].nil? &&
+        req.body[0][:response][:body][:payment_method][:card][:numbers][1].nil? &&
+        req.body[0][:response][:body][:payment_method][:card][:numbers][2].nil? &&
+        req.body[0][:response][:body][:payment_method][:card][:numbers][3].nil? &&
+        req.body[0][:response][:headers]['content-type'.to_sym].nil? &&
+        req.body[0][:response][:headers]['content-encoding'.to_sym].nil?
+      }).to have_been_made.once
     end
   end
 
@@ -324,7 +361,7 @@ describe Supergood do
         ]
       }])
       stub_request(:get, OUTBOUND_URL + '/test_one').to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL + '/test_one')
       Supergood.close
 
@@ -349,7 +386,7 @@ describe Supergood do
         ]
       }])
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL + '/test_one')
       Faraday.get(OUTBOUND_URL + '/test_two')
       Supergood.close
@@ -379,7 +416,7 @@ describe Supergood do
         ]
       }])
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL + '/test_one')
       Supergood.close
 
@@ -415,7 +452,7 @@ describe Supergood do
         ]
       }])
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL + '/test_one')
       Supergood.close
 
@@ -438,9 +475,9 @@ describe Supergood do
 
     it 'does not intercept anything if the remote config can not be fetched' do
       stub_request(:get, OUTBOUND_URL + '/test_one').to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
-      stub_remote_config(config=[], status=500)
+      stub_remote_config([], 500)
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL + '/test_one')
       Supergood.close
 
@@ -454,36 +491,36 @@ describe Supergood do
     it 'tests rest-client' do
       stub_remote_config
       payload = { message: 'success' }.to_json
-      stub_request(:get, OUTBOUND_URL).
-      to_return(status: 200, body: payload, headers: {})
+      stub_request(:get, OUTBOUND_URL)
+        .to_return(status: 200, body: payload, headers: {})
 
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       RestClient.get(OUTBOUND_URL)
-      Supergood.close()
+      Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
         req.body[0][:response][:body].to_json == payload &&
-        req.body[0][:request] != nil
+        !req.body[0][:request].nil?
       }).to have_been_made.once
     end
 
     it 'tests HTTParty' do
       stub_remote_config
       payload = { message: 'success' }.to_json
-      stub_request(:get, OUTBOUND_URL).
-      to_return(status: 200, body: payload, headers: {})
+      stub_request(:get, OUTBOUND_URL)
+        .to_return(status: 200, body: payload, headers: {})
 
-      Supergood.init()
+      Supergood.init({ forceRedactAll: false })
       HTTParty.get(OUTBOUND_URL, { :headers => { 'Accept': 'application/json' }})
-      Supergood.close()
+      Supergood.close
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
         req.body[0][:response][:body].to_json == payload &&
-        req.body[0][:request] != nil
+        !req.body[0][:request].nil?
       }).to have_been_made.once
     end
 
@@ -491,10 +528,10 @@ describe Supergood do
       stub_remote_config
       WebMock.allow_net_connect!
       payload = { message: 'success' }.to_json
-      stub_request(:post, OUTBOUND_URL + '?params=1').
-      to_return(status: 200, body: payload, headers: { 'Content-type' => 'application/json'})
+      stub_request(:post, OUTBOUND_URL + '?params=1')
+        .to_return(status: 200, body: payload, headers: { 'Content-type' => 'application/json'})
 
-      Supergood.init
+      Supergood.init({ forceRedactAll: false })
 
       http = HTTP.accept(:json)
       http.post(OUTBOUND_URL + '?params=1', :body => 'test=123')
@@ -505,7 +542,7 @@ describe Supergood do
       with { |req|
         req.body = JSON.parse(req.body, symbolize_names: true)
         req.body[0][:response][:body].to_json == payload &&
-        req.body[0][:request] != nil
+        !req.body[0][:request].nil?
       }).to have_been_made.once
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -68,9 +68,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        !req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        !req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -89,10 +89,10 @@ describe Supergood do
       Supergood.close()
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body = JSON.parse(req.body)
         req.body.length() == http_error_codes.length() &&
-        req.body[0][:request] != nil &&
-        req.body[0][:response] != nil
+        req.body[0]['request'] != nil &&
+        req.body[0]['response'] != nil
       }).
       to have_been_made.once
     end
@@ -106,10 +106,10 @@ describe Supergood do
       Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        req.body[0][:request][:method] == 'POST' &&
-        !req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        req.body[0]['request']['method'] == 'POST' &&
+        !req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -143,9 +143,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        !req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        !req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -163,9 +163,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        !req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        !req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -187,9 +187,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        !req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        !req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -210,9 +210,9 @@ describe Supergood do
       Supergood.close()
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        !req.body[0][:request].nil? &&
-        req.body[0][:response].nil?
+        req.body = JSON.parse(req.body)
+        !req.body[0]['request'].nil? &&
+        req.body[0]['response'].nil?
       })
         .to have_been_made.once
     end
@@ -222,15 +222,15 @@ describe Supergood do
       stub_remote_config
       stub_request(:get, OUTBOUND_URL).to_return(status: 200, body: { message: 'success' }.to_json, headers: {})
       stub_request(:post,  ENV['SUPERGOOD_BASE_URL'] + '/errors').to_return(status: 200, body: { message: 'Success' }.to_json, headers: {})
-      stub_request(:post,  ENV['SUPERGOOD_BASE_URL'] + '/events').to_raise(SupergoodException.new ERRORS[:POSTING_EVENTS])
+      stub_request(:post,  ENV['SUPERGOOD_BASE_URL'] + '/events').to_raise(SupergoodException.new ERRORS['POSTING_EVENTS'])
 
       Supergood.init({ forceRedactAll: false })
       Faraday.get(OUTBOUND_URL)
       Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/errors').
       with { | req |
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[:error] != nil
+        req.body = JSON.parse(req.body)
+        req.body['error'] != nil
       }).to have_been_made.once
       WebMock.reset!
     end
@@ -259,9 +259,9 @@ describe Supergood do
       Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body = JSON.parse(req.body)
         req.body.length == 1 &&
-        req.body[0][:request][:url] == SECOND_OUTBOUND_URL
+        req.body[0]['request']['url'] == SECOND_OUTBOUND_URL
       }).to have_been_made.once
     end
 
@@ -277,9 +277,9 @@ describe Supergood do
       Supergood.close
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body = JSON.parse(req.body)
         req.body.length == 1 &&
-        req.body[0][:request][:url] == SECOND_OUTBOUND_URL
+        req.body[0]['request']['url'] == SECOND_OUTBOUND_URL
       }).to have_been_made.once
     end
 
@@ -299,9 +299,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:response][:body].to_json == payload &&
-        !req.body[0][:request].nil?
+        req.body = JSON.parse(req.body)
+        req.body[0]['response']['body'].to_json == payload &&
+        !req.body[0]['request'].nil?
       }).to have_been_made.once
     end
   end
@@ -332,18 +332,18 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events')
         .with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:response][:body][:txns][0][:user].nil? &&
-        req.body[0][:response][:body][:txns][0][:id].nil? &&
-        req.body[0][:response][:body][:txns][1][:user].nil? &&
-        req.body[0][:response][:body][:txns][1][:id].nil? &&
-        req.body[0][:response][:body][:payment_method][:type].nil? &&
-        req.body[0][:response][:body][:payment_method][:card][:numbers][0].nil? &&
-        req.body[0][:response][:body][:payment_method][:card][:numbers][1].nil? &&
-        req.body[0][:response][:body][:payment_method][:card][:numbers][2].nil? &&
-        req.body[0][:response][:body][:payment_method][:card][:numbers][3].nil? &&
-        req.body[0][:response][:headers]['content-type'.to_sym].nil? &&
-        req.body[0][:response][:headers]['content-encoding'.to_sym].nil?
+        req.body = JSON.parse(req.body)
+        req.body[0]['response']['body']['txns'][0]['user'].nil? &&
+        req.body[0]['response']['body']['txns'][0]['id'].nil? &&
+        req.body[0]['response']['body']['txns'][1]['user'].nil? &&
+        req.body[0]['response']['body']['txns'][1]['id'].nil? &&
+        req.body[0]['response']['body']['payment_method']['type'].nil? &&
+        req.body[0]['response']['body']['payment_method']['card']['numbers'][0].nil? &&
+        req.body[0]['response']['body']['payment_method']['card']['numbers'][1].nil? &&
+        req.body[0]['response']['body']['payment_method']['card']['numbers'][2].nil? &&
+        req.body[0]['response']['body']['payment_method']['card']['numbers'][3].nil? &&
+        req.body[0]['response']['headers']['content-type'].nil? &&
+        req.body[0]['response']['headers']['content-encoding'].nil?
       }).to have_been_made.once
     end
   end
@@ -367,8 +367,8 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body.length == 1 && req.body[0][:request][:url] == OUTBOUND_URL + '/test_one'
+        req.body = JSON.parse(req.body)
+        req.body.length == 1 && req.body[0]['request']['url'] == OUTBOUND_URL + '/test_one'
       }).to have_been_made.once
     end
 
@@ -393,8 +393,8 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body.length == 1 && req.body[0][:request][:url] == OUTBOUND_URL + '/test_two'
+        req.body = JSON.parse(req.body)
+        req.body.length == 1 && req.body[0]['request']['url'] == OUTBOUND_URL + '/test_two'
       }).to have_been_made.once
     end
 
@@ -422,12 +422,12 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body = JSON.parse(req.body)
         req.body.length == 1 &&
-        req.body[0][:response][:body][:redact_me].nil? &&
-        req.body[0][:metadata][:sensitiveKeys][0][:keyPath] == 'responseBody.redact_me' &&
-        req.body[0][:metadata][:sensitiveKeys][0][:length] == 9 &&
-        req.body[0][:metadata][:sensitiveKeys][0][:type] == 'string'
+        req.body[0]['response']['body']['redact_me'].nil? &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['keyPath'] == 'responseBody.redact_me' &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['length'] == 9 &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['type'] == 'string'
       }).to have_been_made.once
     end
 
@@ -483,29 +483,29 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:metadata][:sensitiveKeys].length == 6 &&
-        req.body[0][:metadata][:sensitiveKeys][0][:keyPath] == 'responseBody.string' &&
-        req.body[0][:metadata][:sensitiveKeys][0][:length] == 6 &&
-        req.body[0][:metadata][:sensitiveKeys][0][:type] == 'string' &&
-        req.body[0][:metadata][:sensitiveKeys][1][:keyPath] == 'responseBody.array' &&
-        req.body[0][:metadata][:sensitiveKeys][1][:length] == 3 &&
-        req.body[0][:metadata][:sensitiveKeys][1][:type] == 'array' &&
-        req.body[0][:metadata][:sensitiveKeys][2][:keyPath] == 'responseBody.object' &&
-        req.body[0][:metadata][:sensitiveKeys][2][:length] == 13 &&
-        req.body[0][:metadata][:sensitiveKeys][2][:type] == 'object' &&
-        req.body[0][:metadata][:sensitiveKeys][3][:keyPath] == 'responseBody.number' &&
-        req.body[0][:metadata][:sensitiveKeys][3][:length] == 3 &&
-        req.body[0][:metadata][:sensitiveKeys][3][:type] == 'integer' &&
-        req.body[0][:metadata][:sensitiveKeys][4][:keyPath] == 'responseBody.boolean' &&
-        req.body[0][:metadata][:sensitiveKeys][4][:length] == 1 &&
-        req.body[0][:metadata][:sensitiveKeys][4][:type] == 'boolean' &&
-        req.body[0][:metadata][:sensitiveKeys][5][:keyPath] == 'responseBody.nothing' # &&
-        req.body[0][:metadata][:sensitiveKeys][5][:length] == 0 &&
-        req.body[0][:metadata][:sensitiveKeys][5][:type] == 'null' &&
-        req.body[0][:metadata][:sensitiveKeys][6][:keyPath] == 'responseBody.float' &&
-        req.body[0][:metadata][:sensitiveKeys][6][:length] == 7 &&
-        req.body[0][:metadata][:sensitiveKeys][6][:type] == 'float'
+        req.body = JSON.parse(req.body)
+        req.body[0]['metadata']['sensitiveKeys'].length == 6 &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['keyPath'] == 'responseBody.string' &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['length'] == 6 &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['type'] == 'string' &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['keyPath'] == 'responseBody.array' &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['length'] == 3 &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['type'] == 'array' &&
+        req.body[0]['metadata']['sensitiveKeys'][2]['keyPath'] == 'responseBody.object' &&
+        req.body[0]['metadata']['sensitiveKeys'][2]['length'] == 13 &&
+        req.body[0]['metadata']['sensitiveKeys'][2]['type'] == 'object' &&
+        req.body[0]['metadata']['sensitiveKeys'][3]['keyPath'] == 'responseBody.number' &&
+        req.body[0]['metadata']['sensitiveKeys'][3]['length'] == 3 &&
+        req.body[0]['metadata']['sensitiveKeys'][3]['type'] == 'integer' &&
+        req.body[0]['metadata']['sensitiveKeys'][4]['keyPath'] == 'responseBody.boolean' &&
+        req.body[0]['metadata']['sensitiveKeys'][4]['length'] == 1 &&
+        req.body[0]['metadata']['sensitiveKeys'][4]['type'] == 'boolean' &&
+        req.body[0]['metadata']['sensitiveKeys'][5]['keyPath'] == 'responseBody.nothing' # &&
+        req.body[0]['metadata']['sensitiveKeys'][5]['length'] == 0 &&
+        req.body[0]['metadata']['sensitiveKeys'][5]['type'] == 'null' &&
+        req.body[0]['metadata']['sensitiveKeys'][6]['keyPath'] == 'responseBody.float' &&
+        req.body[0]['metadata']['sensitiveKeys'][6]['length'] == 7 &&
+        req.body[0]['metadata']['sensitiveKeys'][6]['type'] == 'float'
       }).to have_been_made.once
     end
 
@@ -536,18 +536,18 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
+        req.body = JSON.parse(req.body)
         req.body.length == 1 &&
-        req.body[0][:response][:body][:txns][0][:user].nil? &&
-        req.body[0][:response][:body][:txns][1][:user].nil? &&
-        !req.body[0][:response][:body][:txns][0][:price].nil? &&
-        !req.body[0][:response][:body][:txns][1][:price].nil? &&
-        req.body[0][:metadata][:sensitiveKeys][0][:keyPath] == 'responseBody.txns[0].user' &&
-        req.body[0][:metadata][:sensitiveKeys][0][:length] == 4 &&
-        req.body[0][:metadata][:sensitiveKeys][0][:type] == 'string' &&
-        req.body[0][:metadata][:sensitiveKeys][1][:keyPath] == 'responseBody.txns[1].user' &&
-        req.body[0][:metadata][:sensitiveKeys][1][:length] == 5 &&
-        req.body[0][:metadata][:sensitiveKeys][1][:type] == 'string'
+        req.body[0]['response']['body']['txns'][0]['user'].nil? &&
+        req.body[0]['response']['body']['txns'][1]['user'].nil? &&
+        !req.body[0]['response']['body']['txns'][0]['price'].nil? &&
+        !req.body[0]['response']['body']['txns'][1]['price'].nil? &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['keyPath'] == 'responseBody.txns[0].user' &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['length'] == 4 &&
+        req.body[0]['metadata']['sensitiveKeys'][0]['type'] == 'string' &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['keyPath'] == 'responseBody.txns[1].user' &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['length'] == 5 &&
+        req.body[0]['metadata']['sensitiveKeys'][1]['type'] == 'string'
       }).to have_been_made.once
     end
 
@@ -578,9 +578,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:response][:body].to_json == payload &&
-        !req.body[0][:request].nil?
+        req.body = JSON.parse(req.body)
+        req.body[0]['response']['body'].to_json == payload &&
+        !req.body[0]['request'].nil?
       }).to have_been_made.once
     end
 
@@ -596,9 +596,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:response][:body].to_json == payload &&
-        !req.body[0][:request].nil?
+        req.body = JSON.parse(req.body)
+        req.body[0]['response']['body'].to_json == payload &&
+        !req.body[0]['request'].nil?
       }).to have_been_made.once
     end
 
@@ -618,9 +618,9 @@ describe Supergood do
 
       expect(a_request(:post, ENV['SUPERGOOD_BASE_URL'] + '/events').
       with { |req|
-        req.body = JSON.parse(req.body, symbolize_names: true)
-        req.body[0][:response][:body].to_json == payload &&
-        !req.body[0][:request].nil?
+        req.body = JSON.parse(req.body)
+        req.body[0]['response']['body'].to_json == payload &&
+        !req.body[0]['request'].nil?
       }).to have_been_made.once
     end
   end


### PR DESCRIPTION
- Support ability to fetch remote configuration and redact keys on demand
- Supports config flag, default set to "true" to redact all keys by default (response headers, response body, request headers, request body)